### PR TITLE
en/config/01-quick-guide.md: correct typo in link to AEAD cipher page

### DIFF
--- a/src/content/en/config/01-quick-guide.md
+++ b/src/content/en/config/01-quick-guide.md
@@ -26,7 +26,7 @@ Explanation of each field:
 
 ## Encryption Method
 
-The strongest option is an [AEAD cipher](/en/spec/AEAD-ciphers.html). The recommended
+The strongest option is an [AEAD cipher](/en/spec/AEAD-Ciphers.html). The recommended
 choice is "chacha20-ietf-poly1305" or "aes-256-gcm". Other
 [stream ciphers](/en/spec/Stream-Ciphers.html) are implemented but do not provide
 integrity and authenticity. Unless otherwise specified the encryption method


### PR DESCRIPTION
The current link takes you to <http://www.shadowsocks.org/en/spec/AEAD-ciphers.html> which gives a 404
due to the case-sensitivity of GitHub pages. The correct URL is <http://www.shadowsocks.org/en/spec/AEAD-Ciphers.html> (note the capital C).