### PR TITLE
Small fixes for the website

### DIFF
--- a/src/content/en/config/01-quick-guide.md
+++ b/src/content/en/config/01-quick-guide.md
@@ -89,5 +89,5 @@ This URI can also be encoded to QR code. Then, just scan it with your Android / 
 
 ## SIP002
 
-There is also a new URI scheme purposed in <a ref="https://shadowsocks.org/en/spec/SIP002-URI-Scheme.html">SIP002</a>. Any client or server supports SIP003 plugin should use SIP002 URI scheme instead.
+There is also a new URI scheme proposed in <a href="https://shadowsocks.org/en/spec/SIP002-URI-Scheme.html">SIP002</a>. Any client or server which supports SIP003 plugin should use SIP002 URI scheme instead.
 

--- a/src/content/en/config/01-quick-guide.md
+++ b/src/content/en/config/01-quick-guide.md
@@ -51,6 +51,7 @@ Note that the above URI doesn't follow RFC3986. It means the password here shoul
 For example, we have a server at `192.168.100.1:8888` using `bf-cfb` encryption method and password `test/!@#:`. Then, with the plain URI `ss://bf-cfb:test/!@#:@192.168.100.1:8888`, we can generate the BASE64 encoded URI:
 
 ```
+	> console.log( "ss://" + btoa("bf-cfb:test/!@#:@192.168.100.1:8888") )
 	ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xMDAuMTo4ODg4Cg
 ```
 


### PR DESCRIPTION
Example code can help to explain the concept more clearly than English!

(For example, I wasn't sure if the `ss://` needed to be base64 encoded. It turns out it didn't.)

----

I am still a little confused by the wording:
> Any client or server which supports SIP003 plugin should use SIP002 scheme instead.

Why? Wasn't SIP003 proposed after SIP002? Is SIP003 abandoned?

I wonder if it should say this instead:
> Any client or server which supports SIP003 URI scheme should make sure that it also supports SIP002 URI scheme.