### PR TITLE
Make encoded URI readonly, so it can be copied but not edited

### DIFF
--- a/src/content/en/config/01-quick-guide.md
+++ b/src/content/en/config/01-quick-guide.md
@@ -79,7 +79,7 @@ This URI can also be encoded to QR code. Then, just scan it with your Android / 
 </fieldset>
 <fieldset>
 <label>Encoded:</label>
-<input id="uri-encoded" type="text" disabled="disabled" value=""/>
+<input id="uri-encoded" type="text" readonly="readonly" value=""/>
 </fieldset>
 <fieldset>
 <label>QR Code:</label>


### PR DESCRIPTION
In the _Try it yourself_ section of [the quick guide](https://shadowsocks.org/en/config/quick-guide.html) Firefox will not let us copy text from the Encoded box because it is disabled.

If we convert it to readonly instead, then Firefox can select and copy.

On Chrome the only difference is that our pointer now becomes a caret on hover, instead of an arrow.