### PR TITLE
Link Go implementation to go-shadowsocks2

### DIFF
--- a/src/content/en/download/02-servers.md
+++ b/src/content/en/download/02-servers.md
@@ -2,7 +2,7 @@
 
 shadowsocks-python is the initial version written by [@clowwindy]. It aims to provide a simple-to-use and easy-to-deploy implementation with basic features of shadowsocks.
 
-### PyPI
+#### PyPI
 
 First, make sure you have Python 2.6 or 2.7.
 
@@ -17,7 +17,7 @@ Then install from PIP
 $ pip install shadowsocks
 ```
 
-### GitHub
+#### GitHub
 
 Checkout the source codes and run the scripts directly.
 
@@ -27,17 +27,17 @@ shadowsocks-python is licensed under the [Apache License, Version 2.0](https://w
 
 ## Go
 
-shadowsocks-go is a state-of-the-art port written in Go language, designed for large-scale system. It implements the multi-ports-multi-password feature, which is suitable for paid service providers with user management and traffic statistics support. This port is maintained by [@cyfdecyf].
+[go-shadowsocks2](https://github.com/shadowsocks/go-shadowsocks2) is the next-generation Shadowsocks in Go, maintained by [@riobard], superseds the discontinued [shadowsocks-go](https://github.com/shadowsocks/shadowsocks-go).
 
-### GitHub
+#### GitHub
 
-Use `go get` to install the scripts.
+Use `go get` to install.
 
 ```bash
-$ go get github.com/shadowsocks/shadowsocks-go/cmd/shadowsocks-server
+$ go get -u -v github.com/shadowsocks/go-shadowsocks2
 ```
 
-shadowsocks-go is licensed under the [MIT license](http://opensource.org/licenses/MIT).
+go-shadowsocks2 is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 ## Go from Outline
 
@@ -47,9 +47,9 @@ shadowsocks-go is licensed under the [MIT license](http://opensource.org/license
 * Live updates via config change + SIGHUP
 * Prohibits unsafe access to localhost ports and usage of non-AEAD ciphers
 
-#### Github
+#### GitHub
 
-Download pre-built binaries from the [Github releases](https://github.com/Jigsaw-Code/outline-ss-server/releases) or build it from source:
+Download pre-built binaries from the [GitHub releases](https://github.com/Jigsaw-Code/outline-ss-server/releases) or build it from source:
 ```
 go get github.com/Jigsaw-code/outline-ss-server
 $(go env GOPATH)/bin/outline-ss-server -config=config.yml -metrics=127.0.0.1:9091
@@ -63,7 +63,7 @@ shadowsocks-libev is a lightweight and full featured port for embedded devices
 and low end boxes. It's a pure C implementation and has a very small footprint
 (several megabytes) for thousands of connections. This port is maintained by [@madeye].
 
-### Debian/Ubuntu:
+#### Debian/Ubuntu:
 
 shadowsocks-libev is available in the official repository for Debian
 9("Stretch"), unstable, Ubuntu 16.10 and later derivatives:
@@ -82,7 +82,7 @@ sudo apt-get update
 sudo apt-get -t jessie-backports install shadowsocks-libev
 ```
 
-### Docker
+#### Docker
 
 shadowsocks-libev is shipped also in containers, which makes it a great choice if your cloud provider is Docker-ready or if you aim to build a scalable solution.
 
@@ -93,7 +93,7 @@ docker run -e PASSWORD=<password> -p<server-port>:8388 -p<server-port>:8388/udp 
 
 More information about the image can be found [here](https://github.com/shadowsocks/shadowsocks-libev/blob/master/docker/alpine/README.md).
 
-### GitHub
+#### GitHub
 
 Build and install the project from source codes.
 
@@ -116,11 +116,11 @@ libQtShadowsocks is a lightweight and ultra-fast shadowsocks library written in 
 The client `shadowsocks-libqss` can be used in both client-side and server-side. This port
 is maintained by [@librehat].
 
-### Prebuilt binaries
+#### Prebuilt binaries
 
 Download pre-built binaries from https://github.com/shadowsocks/libQtShadowsocks/releases
 
-### GitHub
+#### GitHub
 
 ```bash
 $ git clone https://github.com/shadowsocks/libQtShadowsocks.git
@@ -135,11 +135,11 @@ libQtShadowsocks is licensed under the [GNU Lesser General Public License, versi
 
 Net::Shadowsocks is an asynchronous, non-blocking Shadowsocks client and server Perl module maintained by [@zhou0].
 
-### Setting up
+#### Setting up
 
 You need a Perl interpreter to execute Perl program. Any Unix like system , including Linux and Mac OS X, has Perl pre-installed. Windows does not have Perl installed by default, you need to install Strawberry Perl.The source code is available on CPAN and github. Download from CPAN https://metacpan.org/release/Net-Shadowsocks or download from github https://github.com/zhou0/shadowsocks-perl
 
-### Installing
+#### Installing
 
 On Unix like systems,either
 
@@ -159,8 +159,9 @@ $ make install
 You might need to change make to dmake or nmake depending on the compiler toolchain used on Windows. If You have cpan, you can also install using this command
 ```bash
 $ cpan Net::Shadowsocks
-```  
-### Running
+```
+
+#### Running
 
 There is a server.pl script under the eg directory. Put your config.json in the same directory as server.pl and
 run the server.pl script there.
@@ -173,4 +174,4 @@ Net::Shadowsocks is licensed under the [Artistic License (2.0)] (http://www.perl
 [@madeye]: https://github.com/madeye
 [@librehat]: https://github.com/librehat
 [@zhou0]: https://github.com/zhou0
-
+[@riobard]: https://github.com/riobard


### PR DESCRIPTION
shadowsocks-go has already been marked as [deprecated](https://github.com/shadowsocks/shadowsocks-go/pull/491), replace it with go-shadowsocks2


Also:
- Github -> GitHub
- Restyle secondary headers with h4 `####` to increase contrast