### PR TITLE
docs: fix links, add mptcp comparison

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -67,14 +67,21 @@ First, you need to pick a shadowsocks server and client implementation. Any impl
 <td>✓</td>
 </tr>
 <tr>
-<td><a href="AEAD-Ciphers">AEAD ciphers</a></td>
+<td><a href="https://en.wikipedia.org/wiki/Multipath_TCP">MPTCP</a></td>
+<td>✗</td>
+<td>✓</td>
+<td>✗</td>
+<td>✗</td>
+</tr>
+<tr>
+<td><a href="aead.html">AEAD ciphers</a></td>
 <td>✓</td>
 <td>✓</td>
 <td>✓</td>
 <td>✓</td>
 </tr>
 <tr>
-<td><a href="Plugin">Plugin</a></td>
+<td><a href="sip003.html">Plugin</a></td>
 <td>✗</td>
 <td>✓</td>
 <td>✗</td>


### PR DESCRIPTION
I observed that the Rust version doesn't support MPTCP (https://github.com/shadowsocks/shadowsocks-rust/issues/1156), and wanted to make that more visible - I wasted a bunch of time installing the Rust version before I realized that it didn't support MPTCP.

While I'm at it, these links seem to have rotted. Per my testing, the new links will work both in Github and on https://shadowsocks.org.