### PR TITLE
Fix typo in sip003.md

### DIFF
--- a/docs/guide/sip003.md
+++ b/docs/guide/sip003.md
@@ -2,7 +2,7 @@
 
 ## Architecture Overview
 
-The plugin of shadowsocks is very similar to the [Pluggable Transport](https://gitweb.torproject.org/torspec.git/tree/pt-spec.txt) plugins from Tor project. Dislike the SOCKS5 proxy design in PT, every SIP003 plugin works as a tunnel (or called local port forwarding). This design aims to avoid per-connection arguments in PT, leading to much easier implementation.
+The plugin of shadowsocks is very similar to the [Pluggable Transport](https://gitweb.torproject.org/torspec.git/tree/pt-spec.txt) plugins from Tor project. Unlike the SOCKS5 proxy design in PT, every SIP003 plugin works as a tunnel (or called local port forwarding). This design aims to avoid per-connection arguments in PT, leading to much easier implementation.
 
 ```
 +------------+                    +---------------------------+


### PR DESCRIPTION
`Dislike` should be `Unlike`.

The meaning of DISLIKE is a feeling of aversion or disgust, while UNLIKE means different, not similar.