### PR TITLE
Convert ASCII diagrams to inline SVG; restore hero color

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,3 @@
+:root {
+  --vp-home-hero-name-color: #10b981;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import DefaultTheme from 'vitepress/theme'
 import SIP002Generator from './components/SIP002Generator.vue'
+import './custom.css'
 
 export default {
   ...DefaultTheme,

--- a/docs/doc/aead.md
+++ b/docs/doc/aead.md
@@ -51,7 +51,7 @@ AE_decrypt(key, nonce, ciphertext, tag) => message
 
 An AEAD encrypted TCP stream starts with a randomly generated salt to derive the per-session subkey, followed by any number of encrypted chunks. Each chunk has the following structure:
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="AEAD TCP chunk: encrypted payload length, length tag, encrypted payload, payload tag">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 40" style="display:block;margin:1em auto;width:100%;height:auto;max-width:720px" role="img" aria-label="AEAD TCP chunk: encrypted payload length, length tag, encrypted payload, payload tag">
   <g fill="none" stroke="currentColor">
     <rect x="10" y="5" width="700" height="30" rx="3"/>
     <line x1="230" y1="5" x2="230" y2="35"/>
@@ -75,7 +75,7 @@ The first AEAD encrypt/decrypt operation uses a counting nonce starting from 0. 
 
 An AEAD encrypted UDP packet has the following structure
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="AEAD UDP packet: salt, encrypted payload, tag">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 40" style="display:block;margin:1em auto;width:100%;height:auto;max-width:500px" role="img" aria-label="AEAD UDP packet: salt, encrypted payload, tag">
   <g fill="none" stroke="currentColor">
     <rect x="10" y="5" width="480" height="30" rx="3"/>
     <line x1="110" y1="5" x2="110" y2="35"/>

--- a/docs/doc/aead.md
+++ b/docs/doc/aead.md
@@ -53,10 +53,10 @@ An AEAD encrypted TCP stream starts with a randomly generated salt to derive the
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="AEAD TCP chunk: encrypted payload length, length tag, encrypted payload, payload tag">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="5" width="220" height="30" rx="3"/>
-    <rect x="230" y="5" width="100" height="30" rx="3"/>
-    <rect x="330" y="5" width="240" height="30" rx="3"/>
-    <rect x="570" y="5" width="140" height="30" rx="3"/>
+    <rect x="10" y="5" width="700" height="30" rx="3"/>
+    <line x1="230" y1="5" x2="230" y2="35"/>
+    <line x1="330" y1="5" x2="330" y2="35"/>
+    <line x1="570" y1="5" x2="570" y2="35"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
     <text x="120" y="24">encrypted payload length</text>
@@ -77,9 +77,9 @@ An AEAD encrypted UDP packet has the following structure
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="AEAD UDP packet: salt, encrypted payload, tag">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="5" width="100" height="30" rx="3"/>
-    <rect x="110" y="5" width="280" height="30" rx="3"/>
-    <rect x="390" y="5" width="100" height="30" rx="3"/>
+    <rect x="10" y="5" width="480" height="30" rx="3"/>
+    <line x1="110" y1="5" x2="110" y2="35"/>
+    <line x1="390" y1="5" x2="390" y2="35"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
     <text x="60" y="24">salt</text>

--- a/docs/doc/aead.md
+++ b/docs/doc/aead.md
@@ -51,9 +51,20 @@ AE_decrypt(key, nonce, ciphertext, tag) => message
 
 An AEAD encrypted TCP stream starts with a randomly generated salt to derive the per-session subkey, followed by any number of encrypted chunks. Each chunk has the following structure:
 
-```
-[encrypted payload length][length tag][encrypted payload][payload tag]
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="AEAD TCP chunk: encrypted payload length, length tag, encrypted payload, payload tag">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="5" width="220" height="30" rx="3"/>
+    <rect x="230" y="5" width="100" height="30" rx="3"/>
+    <rect x="330" y="5" width="240" height="30" rx="3"/>
+    <rect x="570" y="5" width="140" height="30" rx="3"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
+    <text x="120" y="24">encrypted payload length</text>
+    <text x="280" y="24">length tag</text>
+    <text x="450" y="24">encrypted payload</text>
+    <text x="640" y="24">payload tag</text>
+  </g>
+</svg>
 
 Payload length is a 2-byte big-endian unsigned integer capped at 0x3FFF. The higher two bits are reserved and must be set to zero. Payload is therefore limited to 16*1024 - 1 bytes. 
 
@@ -64,9 +75,18 @@ The first AEAD encrypt/decrypt operation uses a counting nonce starting from 0. 
 
 An AEAD encrypted UDP packet has the following structure
 
-```
-[salt][encrypted payload][tag]
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="AEAD UDP packet: salt, encrypted payload, tag">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="5" width="100" height="30" rx="3"/>
+    <rect x="110" y="5" width="280" height="30" rx="3"/>
+    <rect x="390" y="5" width="100" height="30" rx="3"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
+    <text x="60" y="24">salt</text>
+    <text x="250" y="24">encrypted payload</text>
+    <text x="440" y="24">tag</text>
+  </g>
+</svg>
 
 The salt is used to derive the per-session subkey and must be generated randomly to ensure uniqueness. Each UDP packet is encrypted/decrypted independently, using the derived subkey and a nonce with all zero bytes.
 

--- a/docs/doc/sip003.md
+++ b/docs/doc/sip003.md
@@ -4,7 +4,7 @@
 
 The plugin of shadowsocks is very similar to the [Pluggable Transport](https://gitweb.torproject.org/torspec.git/tree/pt-spec.txt) plugins from Tor project. Unlike the SOCKS5 proxy design in PT, every SIP003 plugin works as a tunnel (or called local port forwarding). This design aims to avoid per-connection arguments in PT, leading to much easier implementation.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 280" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SIP003 plugin architecture: SS client and SS server each connect via local loopback to a plugin client/server tunnel, with obfuscated public internet traffic between the two plugin endpoints">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 280" style="display:block;margin:1em auto;width:100%;height:auto;max-width:720px" role="img" aria-label="SIP003 plugin architecture: SS client and SS server each connect via local loopback to a plugin client/server tunnel, with obfuscated public internet traffic between the two plugin endpoints">
   <defs>
     <marker id="sip003-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>

--- a/docs/doc/sip003.md
+++ b/docs/doc/sip003.md
@@ -4,17 +4,33 @@
 
 The plugin of shadowsocks is very similar to the [Pluggable Transport](https://gitweb.torproject.org/torspec.git/tree/pt-spec.txt) plugins from Tor project. Unlike the SOCKS5 proxy design in PT, every SIP003 plugin works as a tunnel (or called local port forwarding). This design aims to avoid per-connection arguments in PT, leading to much easier implementation.
 
-```
-+------------+                    +---------------------------+
-|  SS Client +-- Local Loopback --+  Plugin Client (Tunnel)   +--+
-+------------+                    +---------------------------+  |
-                                                                 |
-            Public Internet (Obfuscated/Transformed traffic) ==> |
-                                                                 |
-+------------+                    +---------------------------+  |
-|  SS Server +-- Local Loopback --+  Plugin Server (Tunnel)   +--+
-+------------+                    +---------------------------+
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 280" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SIP003 plugin architecture: SS client and SS server each connect via local loopback to a plugin client/server tunnel, with obfuscated public internet traffic between the two plugin endpoints">
+  <defs>
+    <marker id="sip003-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <g fill="none" stroke="currentColor">
+    <rect x="20" y="20" width="140" height="50" rx="4"/>
+    <rect x="290" y="20" width="260" height="50" rx="4"/>
+    <rect x="20" y="210" width="140" height="50" rx="4"/>
+    <rect x="290" y="210" width="260" height="50" rx="4"/>
+    <line x1="160" y1="45" x2="290" y2="45"/>
+    <line x1="160" y1="235" x2="290" y2="235"/>
+    <path d="M550 45 L620 45 L620 235 L550 235" stroke-dasharray="0"/>
+    <line x1="620" y1="140" x2="690" y2="140" marker-end="url(#sip003-arr)"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
+    <text x="90" y="50">SS Client</text>
+    <text x="420" y="50">Plugin Client (Tunnel)</text>
+    <text x="90" y="240">SS Server</text>
+    <text x="420" y="240">Plugin Server (Tunnel)</text>
+    <text x="225" y="38" font-size="11">Local Loopback</text>
+    <text x="225" y="228" font-size="11">Local Loopback</text>
+    <text x="360" y="135" font-size="12">Public Internet</text>
+    <text x="360" y="152" font-size="11" opacity="0.75">(Obfuscated / Transformed traffic)</text>
+  </g>
+</svg>
 
 ## Life cycle of a plugin
 

--- a/docs/doc/sip022.md
+++ b/docs/doc/sip022.md
@@ -84,7 +84,7 @@ A length chunk is a 16-bit big-endian unsigned integer that describes the payloa
 
 A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 0x3FFF (16383) length cap in Shadowsocks AEAD does not apply to this edition.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 150" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Length chunk (u16 big-endian) and payload chunk (variable)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 150" style="display:block;margin:1em auto;width:100%;height:auto;max-width:180px" role="img" aria-label="Length chunk (u16 big-endian) and payload chunk (variable)">
   <g fill="none" stroke="currentColor">
     <rect x="10.5" y="0.5" width="159" height="63"/>
     <line x1="10" y1="32" x2="170" y2="32"/>
@@ -101,7 +101,7 @@ A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 
 
 **Request stream:**
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 950 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Request stream: salt, two encrypted header chunks, then repeating length and payload chunks">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 950 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:950px" role="img" aria-label="Request stream: salt, two encrypted header chunks, then repeating length and payload chunks">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="949" height="63"/>
     <line x1="0" y1="32" x2="950" y2="32"/>
@@ -129,7 +129,7 @@ A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 
 
 **Response stream:**
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 950 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Response stream: salt, encrypted header chunk that acts as first length, then repeating payload and length chunks">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 950 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:950px" role="img" aria-label="Response stream: salt, encrypted header chunk that acts as first length, then repeating payload and length chunks">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="949" height="63"/>
     <line x1="0" y1="32" x2="950" y2="32"/>
@@ -159,7 +159,7 @@ A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 
 
 <strong>Request fixed-length header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Request fixed-length header: type, timestamp, length">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:280px" role="img" aria-label="Request fixed-length header: type, timestamp, length">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="279" height="63"/>
     <line x1="0" y1="32" x2="280" y2="32"/>
@@ -178,7 +178,7 @@ A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 
 
 <strong>Request variable-length header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Request variable-length header: ATYP, address, port, padding length, padding, initial payload">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:600px" role="img" aria-label="Request variable-length header: ATYP, address, port, padding length, padding, initial payload">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="599" height="63"/>
     <line x1="0" y1="32" x2="600" y2="32"/>
@@ -206,7 +206,7 @@ A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 
 
 <strong>Response fixed-length header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Response fixed-length header: type, timestamp, request salt, length">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:420px" role="img" aria-label="Response fixed-length header: type, timestamp, request salt, length">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="419" height="63"/>
     <line x1="0" y1="32" x2="420" y2="32"/>
@@ -299,7 +299,7 @@ A UDP packet consists of a separate header and an AEAD-encrypted body. The separ
 
 <strong>Packet:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP packet: encrypted separate header and encrypted body">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:500px" role="img" aria-label="UDP packet: encrypted separate header and encrypted body">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="499" height="63"/>
     <line x1="0" y1="32" x2="500" y2="32"/>
@@ -315,7 +315,7 @@ A UDP packet consists of a separate header and an AEAD-encrypted body. The separ
 
 <strong>Separate header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Separate header: session ID and packet ID">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:240px" role="img" aria-label="Separate header: session ID and packet ID">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="239" height="63"/>
     <line x1="0" y1="32" x2="240" y2="32"/>
@@ -339,7 +339,7 @@ The main header, or message header, is the header at the start of the body. The 
 
 <strong>Client-to-server message header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Client-to-server UDP message header: type, timestamp, padding length, padding, ATYP, address, port">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:680px" role="img" aria-label="Client-to-server UDP message header: type, timestamp, padding length, padding, ATYP, address, port">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="679" height="63"/>
     <line x1="0" y1="32" x2="680" y2="32"/>
@@ -370,7 +370,7 @@ The main header, or message header, is the header at the start of the body. The 
 
 <strong>Server-to-client message header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Server-to-client UDP message header: type, timestamp, client session ID, padding length, padding, ATYP, address, port">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:820px" role="img" aria-label="Server-to-client UDP message header: type, timestamp, client session ID, padding length, padding, ATYP, address, port">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="819" height="63"/>
     <line x1="0" y1="32" x2="820" y2="32"/>
@@ -439,7 +439,7 @@ The same sliding window filter is used for replay protection. It is not necessar
 
 <strong>Packet:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="ChaCha UDP packet: nonce and encrypted body">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:400px" role="img" aria-label="ChaCha UDP packet: nonce and encrypted body">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="399" height="63"/>
     <line x1="0" y1="32" x2="400" y2="32"/>
@@ -455,7 +455,7 @@ The same sliding window filter is used for replay protection. It is not necessar
 
 <strong>Client-to-server message header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="ChaCha client-to-server UDP message header: client session ID, client packet ID, type, timestamp, padding length, padding, ATYP, address, port">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:960px" role="img" aria-label="ChaCha client-to-server UDP message header: client session ID, client packet ID, type, timestamp, padding length, padding, ATYP, address, port">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="959" height="63"/>
     <line x1="0" y1="32" x2="960" y2="32"/>
@@ -492,7 +492,7 @@ The same sliding window filter is used for replay protection. It is not necessar
 
 <strong>Server-to-client message header:</strong>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="ChaCha server-to-client UDP message header: server session ID, server packet ID, type, timestamp, client session ID, padding length, padding, ATYP, address, port">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 64" style="display:block;margin:1em auto;width:100%;height:auto;max-width:1100px" role="img" aria-label="ChaCha server-to-client UDP message header: server session ID, server packet ID, type, timestamp, client session ID, padding length, padding, ATYP, address, port">
   <g fill="none" stroke="currentColor">
     <rect x="0.5" y="0.5" width="1099" height="63"/>
     <line x1="0" y1="32" x2="1100" y2="32"/>

--- a/docs/doc/sip022.md
+++ b/docs/doc/sip022.md
@@ -84,12 +84,12 @@ A length chunk is a 16-bit big-endian unsigned integer that describes the payloa
 
 A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 0x3FFF (16383) length cap in Shadowsocks AEAD does not apply to this edition.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 148" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Length chunk (u16 big-endian) and payload chunk (variable)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 150" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Length chunk (u16 big-endian) and payload chunk (variable)">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="0" width="160" height="64"/>
+    <rect x="10.5" y="0.5" width="159" height="63"/>
     <line x1="10" y1="32" x2="170" y2="32"/>
-    <rect x="10" y="84" width="160" height="64"/>
-    <line x1="10" y1="116" x2="170" y2="116"/>
+    <rect x="10.5" y="85.5" width="159" height="63"/>
+    <line x1="10" y1="117" x2="170" y2="117"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
     <text x="90" y="20" font-size="13">length chunk</text>

--- a/docs/doc/sip022.md
+++ b/docs/doc/sip022.md
@@ -84,58 +84,149 @@ A length chunk is a 16-bit big-endian unsigned integer that describes the payloa
 
 A payload chunk can have up to 0xFFFF (65535) bytes of unencrypted payload. The 0x3FFF (16383) length cap in Shadowsocks AEAD does not apply to this edition.
 
-```
-+----------------+
-|  length chunk  |
-+----------------+
-| u16 big-endian |
-+----------------+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 148" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Length chunk (u16 big-endian) and payload chunk (variable)">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="0" width="160" height="64"/>
+    <line x1="10" y1="32" x2="170" y2="32"/>
+    <rect x="10" y="84" width="160" height="64"/>
+    <line x1="10" y1="116" x2="170" y2="116"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="90" y="20" font-size="13">length chunk</text>
+    <text x="90" y="52" font-size="11" opacity="0.75">u16 big-endian</text>
+    <text x="90" y="104" font-size="13">payload chunk</text>
+    <text x="90" y="136" font-size="11" opacity="0.75">variable</text>
+  </g>
+</svg>
 
-+---------------+
-| payload chunk |
-+---------------+
-|   variable    |
-+---------------+
+**Request stream:**
 
-Request stream:
-+--------+------------------------+---------------------------+------------------------+---------------------------+---+
-|  salt  | encrypted header chunk |  encrypted header chunk   | encrypted length chunk |  encrypted payload chunk  |...|
-+--------+------------------------+---------------------------+------------------------+---------------------------+---+
-| 16/32B |     11B + 16B tag      | variable length + 16B tag |  2B length + 16B tag   | variable length + 16B tag |...|
-+--------+------------------------+---------------------------+------------------------+---------------------------+---+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 950 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Request stream: salt, two encrypted header chunks, then repeating length and payload chunks">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="949" height="63"/>
+    <line x1="0" y1="32" x2="950" y2="32"/>
+    <line x1="80" y1="0" x2="80" y2="64"/>
+    <line x1="270" y1="0" x2="270" y2="64"/>
+    <line x1="490" y1="0" x2="490" y2="64"/>
+    <line x1="690" y1="0" x2="690" y2="64"/>
+    <line x1="910" y1="0" x2="910" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="40" y="20" font-size="13">salt</text>
+    <text x="40" y="52" font-size="11" opacity="0.75">16/32B</text>
+    <text x="175" y="20" font-size="13">encrypted header chunk</text>
+    <text x="175" y="52" font-size="11" opacity="0.75">11B + 16B tag</text>
+    <text x="380" y="20" font-size="13">encrypted header chunk</text>
+    <text x="380" y="52" font-size="11" opacity="0.75">variable length + 16B tag</text>
+    <text x="590" y="20" font-size="13">encrypted length chunk</text>
+    <text x="590" y="52" font-size="11" opacity="0.75">2B length + 16B tag</text>
+    <text x="800" y="20" font-size="13">encrypted payload chunk</text>
+    <text x="800" y="52" font-size="11" opacity="0.75">variable length + 16B tag</text>
+    <text x="930" y="20" font-size="13">...</text>
+    <text x="930" y="52" font-size="11" opacity="0.75">...</text>
+  </g>
+</svg>
 
-Response stream:
-+--------+------------------------+---------------------------+------------------------+---------------------------+---+
-|  salt  | encrypted header chunk |  encrypted payload chunk  | encrypted length chunk |  encrypted payload chunk  |...|
-+--------+------------------------+---------------------------+------------------------+---------------------------+---+
-| 16/32B |    27/43B + 16B tag    | variable length + 16B tag |  2B length + 16B tag   | variable length + 16B tag |...|
-+--------+------------------------+---------------------------+------------------------+---------------------------+---+
-```
+**Response stream:**
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 950 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Response stream: salt, encrypted header chunk that acts as first length, then repeating payload and length chunks">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="949" height="63"/>
+    <line x1="0" y1="32" x2="950" y2="32"/>
+    <line x1="80" y1="0" x2="80" y2="64"/>
+    <line x1="270" y1="0" x2="270" y2="64"/>
+    <line x1="490" y1="0" x2="490" y2="64"/>
+    <line x1="690" y1="0" x2="690" y2="64"/>
+    <line x1="910" y1="0" x2="910" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="40" y="20" font-size="13">salt</text>
+    <text x="40" y="52" font-size="11" opacity="0.75">16/32B</text>
+    <text x="175" y="20" font-size="13">encrypted header chunk</text>
+    <text x="175" y="52" font-size="11" opacity="0.75">27/43B + 16B tag</text>
+    <text x="380" y="20" font-size="13">encrypted payload chunk</text>
+    <text x="380" y="52" font-size="11" opacity="0.75">variable length + 16B tag</text>
+    <text x="590" y="20" font-size="13">encrypted length chunk</text>
+    <text x="590" y="52" font-size="11" opacity="0.75">2B length + 16B tag</text>
+    <text x="800" y="20" font-size="13">encrypted payload chunk</text>
+    <text x="800" y="52" font-size="11" opacity="0.75">variable length + 16B tag</text>
+    <text x="930" y="20" font-size="13">...</text>
+    <text x="930" y="52" font-size="11" opacity="0.75">...</text>
+  </g>
+</svg>
 
 #### 3.1.3. Header
 
+<strong>Request fixed-length header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Request fixed-length header: type, timestamp, length">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="279" height="63"/>
+    <line x1="0" y1="32" x2="280" y2="32"/>
+    <line x1="60" y1="0" x2="60" y2="64"/>
+    <line x1="200" y1="0" x2="200" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="30" y="20" font-size="13">type</text>
+    <text x="30" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="130" y="20" font-size="13">timestamp</text>
+    <text x="130" y="52" font-size="11" opacity="0.75">u64be unix epoch</text>
+    <text x="240" y="20" font-size="13">length</text>
+    <text x="240" y="52" font-size="11" opacity="0.75">u16be</text>
+  </g>
+</svg>
+
+<strong>Request variable-length header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Request variable-length header: ATYP, address, port, padding length, padding, initial payload">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="599" height="63"/>
+    <line x1="0" y1="32" x2="600" y2="32"/>
+    <line x1="60" y1="0" x2="60" y2="64"/>
+    <line x1="160" y1="0" x2="160" y2="64"/>
+    <line x1="240" y1="0" x2="240" y2="64"/>
+    <line x1="360" y1="0" x2="360" y2="64"/>
+    <line x1="460" y1="0" x2="460" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="30" y="20" font-size="13">ATYP</text>
+    <text x="30" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="110" y="20" font-size="13">address</text>
+    <text x="110" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="200" y="20" font-size="13">port</text>
+    <text x="200" y="52" font-size="11" opacity="0.75">u16be</text>
+    <text x="300" y="20" font-size="13">padding length</text>
+    <text x="300" y="52" font-size="11" opacity="0.75">u16be</text>
+    <text x="410" y="20" font-size="13">padding</text>
+    <text x="410" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="530" y="20" font-size="13">initial payload</text>
+    <text x="530" y="52" font-size="11" opacity="0.75">variable</text>
+  </g>
+</svg>
+
+<strong>Response fixed-length header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Response fixed-length header: type, timestamp, request salt, length">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="419" height="63"/>
+    <line x1="0" y1="32" x2="420" y2="32"/>
+    <line x1="60" y1="0" x2="60" y2="64"/>
+    <line x1="200" y1="0" x2="200" y2="64"/>
+    <line x1="340" y1="0" x2="340" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="30" y="20" font-size="13">type</text>
+    <text x="30" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="130" y="20" font-size="13">timestamp</text>
+    <text x="130" y="52" font-size="11" opacity="0.75">u64be unix epoch</text>
+    <text x="270" y="20" font-size="13">request salt</text>
+    <text x="270" y="52" font-size="11" opacity="0.75">16/32B</text>
+    <text x="380" y="20" font-size="13">length</text>
+    <text x="380" y="52" font-size="11" opacity="0.75">u16be</text>
+  </g>
+</svg>
+
 ```
-Request fixed-length header:
-+------+------------------+--------+
-| type |     timestamp    | length |
-+------+------------------+--------+
-|  1B  | u64be unix epoch |  u16be |
-+------+------------------+--------+
-
-Request variable-length header:
-+------+----------+-------+----------------+----------+-----------------+
-| ATYP |  address |  port | padding length |  padding | initial payload |
-+------+----------+-------+----------------+----------+-----------------+
-|  1B  | variable | u16be |     u16be      | variable |    variable     |
-+------+----------+-------+----------------+----------+-----------------+
-
-Response fixed-length header:
-+------+------------------+----------------+--------+
-| type |     timestamp    |  request salt  | length |
-+------+------------------+----------------+--------+
-|  1B  | u64be unix epoch |     16/32B     |  u16be |
-+------+------------------+----------------+--------+
-
 HeaderTypeClientStream = 0
 HeaderTypeServerStream = 1
 MinPaddingLength = 0
@@ -206,21 +297,37 @@ decrypted_body := session_aead_cipher.open(nonce: separate_header[4..16], body)
 
 A UDP packet consists of a separate header and an AEAD-encrypted body. The separate header consists of an 8-byte session ID and an 8-byte big-endian unsigned integer as packet ID. The body is made up of the main header and payload.
 
-```
-Packet:
-+---------------------------+---------------------------+
-| encrypted separate header |       encrypted body      |
-+---------------------------+---------------------------+
-|            16B            | variable length + 16B tag |
-+---------------------------+---------------------------+
+<strong>Packet:</strong>
 
-Separate header:
-+------------+-----------+
-| session ID | packet ID |
-+------------+-----------+
-|     8B     |   u64be   |
-+------------+-----------+
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP packet: encrypted separate header and encrypted body">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="499" height="63"/>
+    <line x1="0" y1="32" x2="500" y2="32"/>
+    <line x1="240" y1="0" x2="240" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="120" y="20" font-size="13">encrypted separate header</text>
+    <text x="120" y="52" font-size="11" opacity="0.75">16B</text>
+    <text x="370" y="20" font-size="13">encrypted body</text>
+    <text x="370" y="52" font-size="11" opacity="0.75">variable length + 16B tag</text>
+  </g>
+</svg>
+
+<strong>Separate header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Separate header: session ID and packet ID">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="239" height="63"/>
+    <line x1="0" y1="32" x2="240" y2="32"/>
+    <line x1="120" y1="0" x2="120" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="60" y="20" font-size="13">session ID</text>
+    <text x="60" y="52" font-size="11" opacity="0.75">8B</text>
+    <text x="180" y="20" font-size="13">packet ID</text>
+    <text x="180" y="52" font-size="11" opacity="0.75">u64be</text>
+  </g>
+</svg>
 
 UDP sessions are initiated by clients. To start a UDP session, the client generates a new random session ID and maintains a counter starting at zero as packet ID. These are used in client-to-server messages and are usually referred to as client session ID and client packet ID.
 
@@ -230,21 +337,72 @@ Servers use client session IDs to identify UDP sessions. For server-to-client me
 
 The main header, or message header, is the header at the start of the body. The client-to-server message header consists of type, timestamp, padding and SOCKS address. The server-to-client message header has an additional client session ID field, which maps the server session to a client session.
 
+<strong>Client-to-server message header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Client-to-server UDP message header: type, timestamp, padding length, padding, ATYP, address, port">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="679" height="63"/>
+    <line x1="0" y1="32" x2="680" y2="32"/>
+    <line x1="60" y1="0" x2="60" y2="64"/>
+    <line x1="200" y1="0" x2="200" y2="64"/>
+    <line x1="320" y1="0" x2="320" y2="64"/>
+    <line x1="420" y1="0" x2="420" y2="64"/>
+    <line x1="480" y1="0" x2="480" y2="64"/>
+    <line x1="580" y1="0" x2="580" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="30" y="20" font-size="13">type</text>
+    <text x="30" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="130" y="20" font-size="13">timestamp</text>
+    <text x="130" y="52" font-size="11" opacity="0.75">u64be unix epoch</text>
+    <text x="260" y="20" font-size="13">padding length</text>
+    <text x="260" y="52" font-size="11" opacity="0.75">u16be</text>
+    <text x="370" y="20" font-size="13">padding</text>
+    <text x="370" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="450" y="20" font-size="13">ATYP</text>
+    <text x="450" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="530" y="20" font-size="13">address</text>
+    <text x="530" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="630" y="20" font-size="13">port</text>
+    <text x="630" y="52" font-size="11" opacity="0.75">u16be</text>
+  </g>
+</svg>
+
+<strong>Server-to-client message header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Server-to-client UDP message header: type, timestamp, client session ID, padding length, padding, ATYP, address, port">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="819" height="63"/>
+    <line x1="0" y1="32" x2="820" y2="32"/>
+    <line x1="60" y1="0" x2="60" y2="64"/>
+    <line x1="200" y1="0" x2="200" y2="64"/>
+    <line x1="340" y1="0" x2="340" y2="64"/>
+    <line x1="460" y1="0" x2="460" y2="64"/>
+    <line x1="560" y1="0" x2="560" y2="64"/>
+    <line x1="620" y1="0" x2="620" y2="64"/>
+    <line x1="720" y1="0" x2="720" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="30" y="20" font-size="13">type</text>
+    <text x="30" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="130" y="20" font-size="13">timestamp</text>
+    <text x="130" y="52" font-size="11" opacity="0.75">u64be unix epoch</text>
+    <text x="270" y="20" font-size="13">client session ID</text>
+    <text x="270" y="52" font-size="11" opacity="0.75">8B</text>
+    <text x="400" y="20" font-size="13">padding length</text>
+    <text x="400" y="52" font-size="11" opacity="0.75">u16be</text>
+    <text x="510" y="20" font-size="13">padding</text>
+    <text x="510" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="590" y="20" font-size="13">ATYP</text>
+    <text x="590" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="670" y="20" font-size="13">address</text>
+    <text x="670" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="770" y="20" font-size="13">port</text>
+    <text x="770" y="52" font-size="11" opacity="0.75">u16be</text>
+  </g>
+</svg>
+
 ```
-Client-to-server message header:
-+------+------------------+----------------+----------+------+----------+-------+
-| type |     timestamp    | padding length |  padding | ATYP |  address |  port |
-+------+------------------+----------------+----------+------+----------+-------+
-|  1B  | u64be unix epoch |     u16be      | variable |  1B  | variable | u16be |
-+------+------------------+----------------+----------+------+----------+-------+
-
-Server-to-client message header:
-+------+------------------+-------------------+----------------+----------+------+----------+-------+
-| type |     timestamp    | client session ID | padding length |  padding | ATYP |  address |  port |
-+------+------------------+-------------------+----------------+----------+------+----------+-------+
-|  1B  | u64be unix epoch |         8B        |     u16be      | variable |  1B  | variable | u16be |
-+------+------------------+-------------------+----------------+----------+------+----------+-------+
-
 HeaderTypeClientPacket = 0
 HeaderTypeServerPacket = 1
 ```
@@ -279,28 +437,98 @@ A UDP packet starts with the random nonce, followed by an encrypted body. The se
 
 The same sliding window filter is used for replay protection. It is not necessary to check for repeated nonce.
 
-```
-Packet:
-+-------+---------------------------+
-| nonce |       encrypted body      |
-+-------+---------------------------+
-|  24B  | variable length + 16B tag |
-+-------+---------------------------+
+<strong>Packet:</strong>
 
-Client-to-server message header:
-+-------------------+------------------+------+------------------+----------------+----------+------+----------+-------+
-| client session ID | client packet ID | type |     timestamp    | padding length |  padding | ATYP |  address |  port |
-+-------------------+------------------+------+------------------+----------------+----------+------+----------+-------+
-|         8B        |       u64be      |  1B  | u64be unix epoch |     u16be      | variable |  1B  | variable | u16be |
-+-------------------+------------------+------+------------------+----------------+----------+------+----------+-------+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="ChaCha UDP packet: nonce and encrypted body">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="399" height="63"/>
+    <line x1="0" y1="32" x2="400" y2="32"/>
+    <line x1="120" y1="0" x2="120" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="60" y="20" font-size="13">nonce</text>
+    <text x="60" y="52" font-size="11" opacity="0.75">24B</text>
+    <text x="260" y="20" font-size="13">encrypted body</text>
+    <text x="260" y="52" font-size="11" opacity="0.75">variable length + 16B tag</text>
+  </g>
+</svg>
 
-Server-to-client message header:
-+-------------------+------------------+------+------------------+-------------------+----------------+----------+------+----------+-------+
-| server session ID | server packet ID | type |     timestamp    | client session ID | padding length |  padding | ATYP |  address |  port |
-+-------------------+------------------+------+------------------+-------------------+----------------+----------+------+----------+-------+
-|         8B        |       u64be      |  1B  | u64be unix epoch |         8B        |     u16be      | variable |  1B  | variable | u16be |
-+-------------------+------------------+------+------------------+-------------------+----------------+----------+------+----------+-------+
-```
+<strong>Client-to-server message header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="ChaCha client-to-server UDP message header: client session ID, client packet ID, type, timestamp, padding length, padding, ATYP, address, port">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="959" height="63"/>
+    <line x1="0" y1="32" x2="960" y2="32"/>
+    <line x1="140" y1="0" x2="140" y2="64"/>
+    <line x1="280" y1="0" x2="280" y2="64"/>
+    <line x1="340" y1="0" x2="340" y2="64"/>
+    <line x1="480" y1="0" x2="480" y2="64"/>
+    <line x1="600" y1="0" x2="600" y2="64"/>
+    <line x1="700" y1="0" x2="700" y2="64"/>
+    <line x1="760" y1="0" x2="760" y2="64"/>
+    <line x1="860" y1="0" x2="860" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="70" y="20" font-size="13">client session ID</text>
+    <text x="70" y="52" font-size="11" opacity="0.75">8B</text>
+    <text x="210" y="20" font-size="13">client packet ID</text>
+    <text x="210" y="52" font-size="11" opacity="0.75">u64be</text>
+    <text x="310" y="20" font-size="13">type</text>
+    <text x="310" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="410" y="20" font-size="13">timestamp</text>
+    <text x="410" y="52" font-size="11" opacity="0.75">u64be unix epoch</text>
+    <text x="540" y="20" font-size="13">padding length</text>
+    <text x="540" y="52" font-size="11" opacity="0.75">u16be</text>
+    <text x="650" y="20" font-size="13">padding</text>
+    <text x="650" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="730" y="20" font-size="13">ATYP</text>
+    <text x="730" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="810" y="20" font-size="13">address</text>
+    <text x="810" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="910" y="20" font-size="13">port</text>
+    <text x="910" y="52" font-size="11" opacity="0.75">u16be</text>
+  </g>
+</svg>
+
+<strong>Server-to-client message header:</strong>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 64" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="ChaCha server-to-client UDP message header: server session ID, server packet ID, type, timestamp, client session ID, padding length, padding, ATYP, address, port">
+  <g fill="none" stroke="currentColor">
+    <rect x="0.5" y="0.5" width="1099" height="63"/>
+    <line x1="0" y1="32" x2="1100" y2="32"/>
+    <line x1="140" y1="0" x2="140" y2="64"/>
+    <line x1="280" y1="0" x2="280" y2="64"/>
+    <line x1="340" y1="0" x2="340" y2="64"/>
+    <line x1="480" y1="0" x2="480" y2="64"/>
+    <line x1="620" y1="0" x2="620" y2="64"/>
+    <line x1="740" y1="0" x2="740" y2="64"/>
+    <line x1="840" y1="0" x2="840" y2="64"/>
+    <line x1="900" y1="0" x2="900" y2="64"/>
+    <line x1="1000" y1="0" x2="1000" y2="64"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="70" y="20" font-size="13">server session ID</text>
+    <text x="70" y="52" font-size="11" opacity="0.75">8B</text>
+    <text x="210" y="20" font-size="13">server packet ID</text>
+    <text x="210" y="52" font-size="11" opacity="0.75">u64be</text>
+    <text x="310" y="20" font-size="13">type</text>
+    <text x="310" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="410" y="20" font-size="13">timestamp</text>
+    <text x="410" y="52" font-size="11" opacity="0.75">u64be unix epoch</text>
+    <text x="550" y="20" font-size="13">client session ID</text>
+    <text x="550" y="52" font-size="11" opacity="0.75">8B</text>
+    <text x="680" y="20" font-size="13">padding length</text>
+    <text x="680" y="52" font-size="11" opacity="0.75">u16be</text>
+    <text x="790" y="20" font-size="13">padding</text>
+    <text x="790" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="870" y="20" font-size="13">ATYP</text>
+    <text x="870" y="52" font-size="11" opacity="0.75">1B</text>
+    <text x="950" y="20" font-size="13">address</text>
+    <text x="950" y="52" font-size="11" opacity="0.75">variable</text>
+    <text x="1050" y="20" font-size="13">port</text>
+    <text x="1050" y="52" font-size="11" opacity="0.75">u16be</text>
+  </g>
+</svg>
 
 ## Acknowledgement
 

--- a/docs/doc/sip023.md
+++ b/docs/doc/sip023.md
@@ -30,7 +30,7 @@ When iPSKs are used, the separate header MUST be encrypted with the first iPSK. 
 
 ## Scenarios
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 480" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SIP023 identity header scenarios: four clients relay through relay0 to server0 and server1, each with their own PSK set">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 480" style="display:block;margin:1em auto;width:100%;height:auto;max-width:860px" role="img" aria-label="SIP023 identity header scenarios: four clients relay through relay0 to server0 and server1, each with their own PSK set">
   <defs>
     <marker id="sip023-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>

--- a/docs/doc/sip023.md
+++ b/docs/doc/sip023.md
@@ -30,19 +30,46 @@ When iPSKs are used, the separate header MUST be encrypted with the first iPSK. 
 
 ## Scenarios
 
-```
-      client0       >---+
-(iPSK0:iPSK1:uPSK0)      \
-                          \
-      client1       >------\                        +--->    server0 [iPSK1]
-(iPSK0:iPSK1:uPSK1)         \                      /      [uPSK0, uPSK1, uPSK2]
-                             >-> relay0 [iPSK0] >-<
-      client2               /    [iPSK1, uPSK3]    \
-(iPSK0:iPSK1:uPSK2) >------/                        +--->    server1 [uPSK3]
-                          /
-      client3            /
-   (iPSK0:uPSK3)    >---+
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 480" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SIP023 identity header scenarios: four clients relay through relay0 to server0 and server1, each with their own PSK set">
+  <defs>
+    <marker id="sip023-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <g fill="none" stroke="currentColor">
+    <rect x="20" y="20" width="200" height="60" rx="4"/>
+    <rect x="20" y="140" width="200" height="60" rx="4"/>
+    <rect x="20" y="260" width="200" height="60" rx="4"/>
+    <rect x="20" y="380" width="200" height="60" rx="4"/>
+    <rect x="360" y="200" width="180" height="80" rx="4"/>
+    <rect x="650" y="80" width="190" height="80" rx="4"/>
+    <rect x="650" y="320" width="190" height="60" rx="4"/>
+    <path d="M220 50 L360 240" marker-end="url(#sip023-arr)"/>
+    <path d="M220 170 L360 240" marker-end="url(#sip023-arr)"/>
+    <path d="M220 290 L360 240" marker-end="url(#sip023-arr)"/>
+    <path d="M220 410 L360 240" marker-end="url(#sip023-arr)"/>
+    <path d="M540 240 L650 120" marker-end="url(#sip023-arr)"/>
+    <path d="M540 240 L650 350" marker-end="url(#sip023-arr)"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="120" y="48" font-size="14">client0</text>
+    <text x="120" y="68" font-size="11" opacity="0.75">(iPSK0:iPSK1:uPSK0)</text>
+    <text x="120" y="168" font-size="14">client1</text>
+    <text x="120" y="188" font-size="11" opacity="0.75">(iPSK0:iPSK1:uPSK1)</text>
+    <text x="120" y="288" font-size="14">client2</text>
+    <text x="120" y="308" font-size="11" opacity="0.75">(iPSK0:iPSK1:uPSK2)</text>
+    <text x="120" y="408" font-size="14">client3</text>
+    <text x="120" y="428" font-size="11" opacity="0.75">(iPSK0:uPSK3)</text>
+    <text x="450" y="234" font-size="14">relay0</text>
+    <text x="450" y="252" font-size="11" opacity="0.75">[iPSK0]</text>
+    <text x="450" y="270" font-size="11" opacity="0.75">[iPSK1, uPSK3]</text>
+    <text x="745" y="108" font-size="14">server0</text>
+    <text x="745" y="126" font-size="11" opacity="0.75">[iPSK1]</text>
+    <text x="745" y="146" font-size="11" opacity="0.75">[uPSK0, uPSK1, uPSK2]</text>
+    <text x="745" y="348" font-size="14">server1</text>
+    <text x="745" y="366" font-size="11" opacity="0.75">[uPSK3]</text>
+  </g>
+</svg>
 
 A set of PSKs, delimited by `:`, are assigned to each client. To send a request, a client MUST generate one identity header for each iPSK.
 

--- a/docs/doc/what-is-shadowsocks.md
+++ b/docs/doc/what-is-shadowsocks.md
@@ -2,9 +2,29 @@
 
 Shadowsocks is a secure split proxy loosely based on [SOCKS5](https://tools.ietf.org/html/rfc1928).
 
-```
-client <---> ss-local <--[encrypted]--> ss-remote <---> target
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 70" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Shadowsocks data flow: client to ss-local to ss-remote to target, with encrypted link between ss-local and ss-remote">
+  <defs>
+    <marker id="ss-arr-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="15" width="90" height="40" rx="4"/>
+    <rect x="180" y="15" width="100" height="40" rx="4"/>
+    <rect x="440" y="15" width="100" height="40" rx="4"/>
+    <rect x="620" y="15" width="90" height="40" rx="4"/>
+    <line x1="100" y1="35" x2="180" y2="35" marker-start="url(#ss-arr-1)" marker-end="url(#ss-arr-1)"/>
+    <line x1="280" y1="35" x2="440" y2="35" marker-start="url(#ss-arr-1)" marker-end="url(#ss-arr-1)"/>
+    <line x1="540" y1="35" x2="620" y2="35" marker-start="url(#ss-arr-1)" marker-end="url(#ss-arr-1)"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" text-anchor="middle">
+    <text x="55" y="40">client</text>
+    <text x="230" y="40">ss-local</text>
+    <text x="490" y="40">ss-remote</text>
+    <text x="665" y="40">target</text>
+    <text x="360" y="28" font-size="11">encrypted</text>
+  </g>
+</svg>
 
 
 The Shadowsocks local component (ss-local) acts like a traditional SOCKS5 server and provides proxy service to clients. It encrypts and forwards data streams and packets from the client to the Shadowsocks remote component (ss-remote), which decrypts and forwards to the target. Replies from target are similarly encrypted and relayed by ss-remote back to ss-local, which decrypts and eventually returns to the original client.
@@ -13,9 +33,21 @@ The Shadowsocks local component (ss-local) acts like a traditional SOCKS5 server
 
 Addresses used in Shadowsocks follow the [SOCKS5 address format](https://tools.ietf.org/html/rfc1928#section-5):
 
-```
-[1-byte type][variable-length host][2-byte port]
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 60" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SOCKS5 address format: 1-byte type, variable-length host, 2-byte port">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="10" width="120" height="40" rx="3"/>
+    <rect x="130" y="10" width="280" height="40" rx="3"/>
+    <rect x="410" y="10" width="120" height="40" rx="3"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
+    <text x="70" y="28" font-size="13">type</text>
+    <text x="70" y="44" font-size="11" opacity="0.7">1B</text>
+    <text x="270" y="28" font-size="13">host</text>
+    <text x="270" y="44" font-size="11" opacity="0.7">variable</text>
+    <text x="470" y="28" font-size="13">port</text>
+    <text x="470" y="44" font-size="11" opacity="0.7">2B</text>
+  </g>
+</svg>
 
 The following address types are defined:
 
@@ -30,9 +62,16 @@ The port number is a 2-byte big-endian unsigned integer.
 
 ss-local initiates a TCP connection to ss-remote by sending an encrypted data stream starting with the target address followed by payload data. The exact encryption scheme differs depending on the cipher used.
 
-```
-[target address][payload]
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="TCP stream payload format: target address followed by payload">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="5" width="200" height="30" rx="3"/>
+    <rect x="210" y="5" width="260" height="30" rx="3"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
+    <text x="110" y="24">target address</text>
+    <text x="340" y="24">payload</text>
+  </g>
+</svg>
 
 ss-remote receives the encrypted data stream, decrypts and parses the leading target address. It then establishes a new TCP connection to the target and forwards payload data to it. ss-remote receives reply from the target, encrypts and forwards it back to the ss-local, until ss-local disconnects.
 
@@ -42,14 +81,28 @@ For better obfuscation purposes, both local and remote SHOULD send the handshake
 
 ss-local sends an encrypted data packet containing the target address and payload to ss-remote.
 
-```
-[target address][payload]
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP packet payload format: target address followed by payload">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="5" width="200" height="30" rx="3"/>
+    <rect x="210" y="5" width="260" height="30" rx="3"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
+    <text x="110" y="24">target address</text>
+    <text x="340" y="24">payload</text>
+  </g>
+</svg>
 
 Upon receiving the encrypted packet, ss-remote decrypts and parses the target address. It then sends a new data packet containing only the payload to the target. ss-remote receives data packets back from target and prepends the target address to the payload in each packet, then sends encrypted copies back to ss-local.
 
-```
-[target address][payload]
-```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP reply packet format: target address followed by payload">
+  <g fill="none" stroke="currentColor">
+    <rect x="10" y="5" width="200" height="30" rx="3"/>
+    <rect x="210" y="5" width="260" height="30" rx="3"/>
+  </g>
+  <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
+    <text x="110" y="24">target address</text>
+    <text x="340" y="24">payload</text>
+  </g>
+</svg>
 
 Essentially, ss-remote is performing Network Address Translation for ss-local.

--- a/docs/doc/what-is-shadowsocks.md
+++ b/docs/doc/what-is-shadowsocks.md
@@ -35,9 +35,9 @@ Addresses used in Shadowsocks follow the [SOCKS5 address format](https://tools.i
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 60" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SOCKS5 address format: 1-byte type, variable-length host, 2-byte port">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="10" width="120" height="40" rx="3"/>
-    <rect x="130" y="10" width="280" height="40" rx="3"/>
-    <rect x="410" y="10" width="120" height="40" rx="3"/>
+    <rect x="10" y="10" width="520" height="40" rx="3"/>
+    <line x1="130" y1="10" x2="130" y2="50"/>
+    <line x1="410" y1="10" x2="410" y2="50"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" text-anchor="middle">
     <text x="70" y="28" font-size="13">type</text>
@@ -64,8 +64,8 @@ ss-local initiates a TCP connection to ss-remote by sending an encrypted data st
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="TCP stream payload format: target address followed by payload">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="5" width="200" height="30" rx="3"/>
-    <rect x="210" y="5" width="260" height="30" rx="3"/>
+    <rect x="10" y="5" width="460" height="30" rx="3"/>
+    <line x1="210" y1="5" x2="210" y2="35"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
     <text x="110" y="24">target address</text>
@@ -83,8 +83,8 @@ ss-local sends an encrypted data packet containing the target address and payloa
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP packet payload format: target address followed by payload">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="5" width="200" height="30" rx="3"/>
-    <rect x="210" y="5" width="260" height="30" rx="3"/>
+    <rect x="10" y="5" width="460" height="30" rx="3"/>
+    <line x1="210" y1="5" x2="210" y2="35"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
     <text x="110" y="24">target address</text>
@@ -96,8 +96,8 @@ Upon receiving the encrypted packet, ss-remote decrypts and parses the target ad
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP reply packet format: target address followed by payload">
   <g fill="none" stroke="currentColor">
-    <rect x="10" y="5" width="200" height="30" rx="3"/>
-    <rect x="210" y="5" width="260" height="30" rx="3"/>
+    <rect x="10" y="5" width="460" height="30" rx="3"/>
+    <line x1="210" y1="5" x2="210" y2="35"/>
   </g>
   <g fill="currentColor" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" text-anchor="middle">
     <text x="110" y="24">target address</text>

--- a/docs/doc/what-is-shadowsocks.md
+++ b/docs/doc/what-is-shadowsocks.md
@@ -2,7 +2,7 @@
 
 Shadowsocks is a secure split proxy loosely based on [SOCKS5](https://tools.ietf.org/html/rfc1928).
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 70" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="Shadowsocks data flow: client to ss-local to ss-remote to target, with encrypted link between ss-local and ss-remote">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 70" style="display:block;margin:1em auto;width:100%;height:auto;max-width:720px" role="img" aria-label="Shadowsocks data flow: client to ss-local to ss-remote to target, with encrypted link between ss-local and ss-remote">
   <defs>
     <marker id="ss-arr-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
@@ -33,7 +33,7 @@ The Shadowsocks local component (ss-local) acts like a traditional SOCKS5 server
 
 Addresses used in Shadowsocks follow the [SOCKS5 address format](https://tools.ietf.org/html/rfc1928#section-5):
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 60" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="SOCKS5 address format: 1-byte type, variable-length host, 2-byte port">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 60" style="display:block;margin:1em auto;width:100%;height:auto;max-width:540px" role="img" aria-label="SOCKS5 address format: 1-byte type, variable-length host, 2-byte port">
   <g fill="none" stroke="currentColor">
     <rect x="10" y="10" width="520" height="40" rx="3"/>
     <line x1="130" y1="10" x2="130" y2="50"/>
@@ -62,7 +62,7 @@ The port number is a 2-byte big-endian unsigned integer.
 
 ss-local initiates a TCP connection to ss-remote by sending an encrypted data stream starting with the target address followed by payload data. The exact encryption scheme differs depending on the cipher used.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="TCP stream payload format: target address followed by payload">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;width:100%;height:auto;max-width:480px" role="img" aria-label="TCP stream payload format: target address followed by payload">
   <g fill="none" stroke="currentColor">
     <rect x="10" y="5" width="460" height="30" rx="3"/>
     <line x1="210" y1="5" x2="210" y2="35"/>
@@ -81,7 +81,7 @@ For better obfuscation purposes, both local and remote SHOULD send the handshake
 
 ss-local sends an encrypted data packet containing the target address and payload to ss-remote.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP packet payload format: target address followed by payload">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;width:100%;height:auto;max-width:480px" role="img" aria-label="UDP packet payload format: target address followed by payload">
   <g fill="none" stroke="currentColor">
     <rect x="10" y="5" width="460" height="30" rx="3"/>
     <line x1="210" y1="5" x2="210" y2="35"/>
@@ -94,7 +94,7 @@ ss-local sends an encrypted data packet containing the target address and payloa
 
 Upon receiving the encrypted packet, ss-remote decrypts and parses the target address. It then sends a new data packet containing only the payload to the target. ss-remote receives data packets back from target and prepends the target address to the payload in each packet, then sends encrypted copies back to ss-local.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;max-width:100%" role="img" aria-label="UDP reply packet format: target address followed by payload">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 40" style="display:block;margin:1em auto;width:100%;height:auto;max-width:480px" role="img" aria-label="UDP reply packet format: target address followed by payload">
   <g fill="none" stroke="currentColor">
     <rect x="10" y="5" width="460" height="30" rx="3"/>
     <line x1="210" y1="5" x2="210" y2="35"/>


### PR DESCRIPTION
## Summary
- Replace ASCII box-drawing diagrams in `what-is-shadowsocks.md`, `aead.md`, `sip003.md`, `sip022.md`, and `sip023.md` with inline SVG using `currentColor`, so strokes and text follow the VitePress light/dark toggle automatically (no paired asset files, no `prefers-color-scheme` workaround).
- Pin `--vp-home-hero-name-color` to the pre-upgrade emerald green (`#10b981`) via a small custom stylesheet. The homepage "Shadowsocks" title shifted to indigo after the VitePress 1.0.0-alpha.75 → 1.6.4 upgrade because the default `--vp-c-brand` was rebased onto indigo. This restores the prior look without touching any other brand surface.

## Test plan
- [ ] `npm run docs:build` succeeds
- [ ] Homepage hero "Shadowsocks" is emerald green in both light and dark themes
- [ ] `/doc/what-is-shadowsocks` flow and byte-field diagrams render in light and dark
- [ ] `/doc/aead` TCP chunk and UDP packet diagrams render in both themes
- [ ] `/doc/sip003` plugin architecture diagram renders in both themes
- [ ] `/doc/sip022` all 14 packet/header diagrams render; wide ones scale to container
- [ ] `/doc/sip023` client/relay/server topology renders in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)